### PR TITLE
Remove Browserify as an optionalDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,5 @@
   },
   "dependencies": {
     "lodash": "~1.0.1"
-  },
-  "optionalDependencies": {
-    "browserify": "2"
   }
 }


### PR DESCRIPTION
I don't think it makes any sense to have it as an optionalDependency. `npm` will still try to install it, it just won't completely bomb out if it fails.

Can you just show some examples of it being used with `browserify` in the README?
