### PR TITLE
Parse fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ node_js:
 branches:
     only:
           - master
+          - parse-fixtures

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
     },
 
     watch: {
-      files: ['index.js', 'Gruntfile.js', '**/*.js', '!node_modules/**/*'],
+      files: ['index.js', 'Gruntfile.js', '**/*.js', '**/*.json', '!node_modules/**/*'],
       tasks: ['default']
     },
   })

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+
+   mochaTest: {
+      test: {
+        options: {
+          reporter: 'spec',
+          recursive: false
+        },
+        src: ['test/init.js']
+      }
+    },
+
+    watch: {
+      files: ['index.js', 'Gruntfile.js', '**/*.js', '!node_modules/**/*'],
+      tasks: ['default']
+    },
+  })
+
+  grunt.loadNpmTasks('grunt-mocha-test')
+  grunt.loadNpmTasks('grunt-contrib-watch')
+
+  grunt.registerTask('default', ['mochaTest'])
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   "devDependencies": {
     "chai": "~1.5.0",
     "sinon-chai": "~2.3.1",
-    "mocha": "~1.8.1"
+    "mocha": "~1.8.1",
+    "grunt": "~0.4.1",
+    "grunt-mocha-test": "~0.7.0",
+    "grunt-contrib-watch": "~0.5.3"
   },
   "dependencies": {
     "lodash": "~1.0.1"

--- a/src/link.js
+++ b/src/link.js
@@ -21,8 +21,8 @@ function Link(desc) {
   }
 
   this.templated = desc.templated === true;
-  
-  
+
+
   if (has('deprecation') && !validate('deprecation', 'Boolean') && !validate('deprecation', 'String')) {
     throw new TypeError('Invalid Link deprecation provided');
   }
@@ -30,7 +30,7 @@ function Link(desc) {
   this.deprecationInfo = !desc.deprecation || _.isBoolean(desc.deprecation) ? null : desc.deprecation;
 
 
-  ['type', 'name', 'profile', 'title', 'hreflang'].forEach(function (prop) {
+  ['type', 'name', 'profile', 'title', 'href', 'hreflang'].forEach(function (prop) {
     if (has(prop) && !validate(prop, 'String')) {
       throw new Error('Invalid link property "' + prop + '" provided.');
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,18 +1,18 @@
 var Resource = require('./resource');
 var _ = require('lodash');
 
-function parser(json) {
+function parser(halObject) {
   "use strict";
- 
-  json = _.cloneDeep(json);
 
-  var links = json._links;
-  delete json._links;
+  var unparsedResource = _.cloneDeep(halObject);
 
-  var embedded = json._embedded;
-  delete json._embedded;
+  var links = unparsedResource._links;
+  delete unparsedResource._links;
 
-  return new Resource(json, links, embedded);
+  var embedded = unparsedResource._embedded;
+  delete unparsedResource._embedded;
+
+  return new Resource(unparsedResource, links, embedded, parser);
 }
 module.exports = parser;
 

--- a/src/resource.js
+++ b/src/resource.js
@@ -11,10 +11,11 @@ function parseEmbedded(embedded, parser) {
   return parsed;
 }
 
-function Resource(json, links, embedded, parser) {
+function Resource(unparsedResource, links, embedded, parser) {
   "use strict";
+  var self = this
 
-  if (!utils.isObjectLiteral(json)) {
+  if (!utils.isObjectLiteral(unparsedResource)) {
     throw new Error('No object provided');
   }
 
@@ -22,7 +23,7 @@ function Resource(json, links, embedded, parser) {
   var resourceLinks = new ResourceLinks(links);
 
   this.toJSON = function () {
-    return json;
+    return unparsedResource;
   };
 
   this.embedded = function (key) {
@@ -32,6 +33,12 @@ function Resource(json, links, embedded, parser) {
   this.links = function (key) {
     return key ? resourceLinks.get(key) : resourceLinks;
   };
+
+  // copy non-hal properties (everything that is not _links or _embedded) to
+  // new resource
+  Object.keys(unparsedResource).forEach(function(key) {
+    self[key] = unparsedResource[key];
+  });
 }
 
 module.exports = Resource;

--- a/src/resource.js
+++ b/src/resource.js
@@ -1,8 +1,7 @@
-var parser = require('./parser'),
-    ResourceLinks = require('./links'),
+var ResourceLinks = require('./links'),
     utils = require('./utils');
 
-function parseEmbedded(embedded) {
+function parseEmbedded(embedded, parser) {
   "use strict";
   var parsed = {};
   Object.keys(embedded).forEach(function (key) {
@@ -12,13 +11,14 @@ function parseEmbedded(embedded) {
   return parsed;
 }
 
-function Resource(json, links, embedded) {
+function Resource(json, links, embedded, parser) {
   "use strict";
+
   if (!utils.isObjectLiteral(json)) {
     throw new Error('No object provided');
   }
 
-  var embeddedResources = parseEmbedded(embedded || {});
+  var embeddedResources = parseEmbedded(embedded || {}, parser);
   var resourceLinks = new ResourceLinks(links);
 
   this.toJSON = function () {

--- a/test/fixtures/ex1.json
+++ b/test/fixtures/ex1.json
@@ -7,8 +7,9 @@
       { "href": "/admins/2", "title": "Fred" },
       { "href": "/admins/5", "title": "Kate" }
     ]
-  currentlyProcessing: 14,
-  shippedToday: 20,
+  },
+  "currentlyProcessing": 14,
+  "shippedToday": 20,
   "_embedded": {
    "orders": [{
        "_links": {
@@ -18,7 +19,7 @@
        },
        "total": 30.00,
        "currency": "USD",
-       "status": "shipped",
+       "status": "shipped"
      },{
        "_links": {
          "self": { "href": "/orders/124" },

--- a/test/fixtures/ex1.json
+++ b/test/fixtures/ex1.json
@@ -2,12 +2,13 @@
   "_links": {
     "self": { "href": "/orders" },
     "next": { "href": "/orders?page=2" },
-    "find": { "href": "/orders{?id}", "templated": true },
-    "admin": [
-      { "href": "/admins/2", "title": "Fred" },
-      { "href": "/admins/5", "title": "Kate" }
-    ]
+    "find": { "href": "/orders{?id}", "templated": true }
   },
+  "admin": [
+     { "href": "/admins/2", "title": "Fred" },
+     { "href": "/admins/5", "title": "Kate" },
+     { "comment": "Rel 'admin' should be a link but halbert currently fails to parse links that are arrays of link objects" }
+   ],
   "currentlyProcessing": 14,
   "shippedToday": 20,
   "_embedded": {

--- a/test/fixtures/minimal.json
+++ b/test/fixtures/minimal.json
@@ -1,5 +1,5 @@
 {
   "_links": {
-    "self": "dummy"
+    "self": { "href": "dummy" }
   }
 }

--- a/test/specs/fixture_util.js
+++ b/test/specs/fixture_util.js
@@ -1,0 +1,3 @@
+exports.read = function(name) {
+  return require('../fixtures/' + name + '.json');
+}

--- a/test/specs/parser_spec.js
+++ b/test/specs/parser_spec.js
@@ -1,6 +1,7 @@
 /*global it:true, describe:true*/
 var parser = require('../../src/parser'),
-    Resource = require('../../src/resource');
+    Resource = require('../../src/resource'),
+    fixtures = require('./fixture_util');
 
 describe("HAL-Parser", function () {
   "use strict";
@@ -21,6 +22,32 @@ describe("HAL-Parser", function () {
 
     parser(json);
     json.should.contain.keys(['_links', 'embedded', 'prop']);
+  });
+
+  it("should parse the minimal example fixture", function () {
+    var json = fixtures.read('minimal')
+    var resource = parser(json);
+    resource.links().should.exist
+    resource.links('self').should.exist
+    resource.links('self').href.should.equal('dummy')
+  });
+
+  it.skip("should parse the fixture example 1", function () {
+    var json = fixtures.read('ex1')
+    var resource = parser(json);
+    /*
+    Now some assertions like the following should follow. Unfortunately, parsing
+    already breaks due to embedded resources.
+
+    resource.links().should.exist
+    resource.links('self').href.should.equal('/orders')
+    resource.links('next').href.should.equal('/orders?page=2')
+    resource.links('find').href.should.equal('/orders{?id}')
+    resource.links('find').templated.should.be.true
+    ...
+    resource.embedded().should.exist
+    ...
+    */
   });
 });
 

--- a/test/specs/parser_spec.js
+++ b/test/specs/parser_spec.js
@@ -36,8 +36,6 @@ describe("HAL-Parser", function () {
     var json = fixtures.read('ex1');
     var resource = parser(json);
 
-    console.log(JSON.stringify(resource));
-
     resource.links().should.exist;
     resource.links('self').href.should.equal('/orders');
     resource.links('self').templated.should.be.false;

--- a/test/specs/parser_spec.js
+++ b/test/specs/parser_spec.js
@@ -32,22 +32,24 @@ describe("HAL-Parser", function () {
     resource.links('self').href.should.equal('dummy')
   });
 
-  it.skip("should parse the fixture example 1", function () {
+  it("should parse the fixture example 1", function () {
     var json = fixtures.read('ex1')
     var resource = parser(json);
-    /*
-    Now some assertions like the following should follow. Unfortunately, parsing
-    already breaks due to embedded resources.
+
+    console.log(JSON.stringify(resource))
 
     resource.links().should.exist
     resource.links('self').href.should.equal('/orders')
+    resource.links('self').templated.should.be.false
     resource.links('next').href.should.equal('/orders?page=2')
     resource.links('find').href.should.equal('/orders{?id}')
     resource.links('find').templated.should.be.true
-    ...
+    // TODO add assertions for admin link object array here once that works
+
+    // resource.currentlyProcessing.should.equal(14)
+    //resource.shippedToday.should.equal(20)
+
     resource.embedded().should.exist
-    ...
-    */
   });
 });
 

--- a/test/specs/parser_spec.js
+++ b/test/specs/parser_spec.js
@@ -27,29 +27,46 @@ describe("HAL-Parser", function () {
   it("should parse the minimal example fixture", function () {
     var json = fixtures.read('minimal')
     var resource = parser(json);
-    resource.links().should.exist
-    resource.links('self').should.exist
-    resource.links('self').href.should.equal('dummy')
+    resource.links().should.exist;
+    resource.links('self').should.exist;
+    resource.links('self').href.should.equal('dummy');
   });
 
   it("should parse the fixture example 1", function () {
-    var json = fixtures.read('ex1')
+    var json = fixtures.read('ex1');
     var resource = parser(json);
 
-    console.log(JSON.stringify(resource))
+    console.log(JSON.stringify(resource));
 
-    resource.links().should.exist
-    resource.links('self').href.should.equal('/orders')
-    resource.links('self').templated.should.be.false
-    resource.links('next').href.should.equal('/orders?page=2')
-    resource.links('find').href.should.equal('/orders{?id}')
-    resource.links('find').templated.should.be.true
+    resource.links().should.exist;
+    resource.links('self').href.should.equal('/orders');
+    resource.links('self').templated.should.be.false;
+    resource.links('next').href.should.equal('/orders?page=2');
+    resource.links('find').href.should.equal('/orders{?id}');
+    resource.links('find').templated.should.be.true;
     // TODO add assertions for admin link object array here once that works
 
-    // resource.currentlyProcessing.should.equal(14)
-    //resource.shippedToday.should.equal(20)
+    resource.currentlyProcessing.should.equal(14);
+    resource.shippedToday.should.equal(20);
 
-    resource.embedded().should.exist
+    resource.embedded().should.exist;
+    var orders = resource.embedded('orders');
+    var order1 = orders[0];
+    var order2 = orders[1];
+
+    order1.links('self').href.should.equal('/orders/123')
+    order1.links('basket').href.should.equal('/baskets/98712')
+    order1.links('customer').href.should.equal('/customers/7809')
+    order1.total.should.equal(30)
+    order1.currency.should.equal('USD')
+    order1.status.should.equal('shipped')
+
+    order2.links('self').href.should.equal('/orders/124')
+    order2.links('basket').href.should.equal('/baskets/97213')
+    order2.links('customer').href.should.equal('/customers/12369')
+    order2.total.should.equal(20)
+    order2.currency.should.equal('USD')
+    order2.status.should.equal('processing')
   });
 });
 


### PR DESCRIPTION
This PR addresses a number of issues
- Adds a basic Grunt build file to the project
- Makes the href property available in Link objects
- Fixes broken JSON in the test fixtures
- Adds tests to parse the test fixtures to parse_spec.js
- Removes a cyclic require-dependency (thereby fixing a bug with embedded resources)
- Make non-hal properties available in Resource object

I also renamed some local variables - maybe I should have refrained from doing so to keep the PR more focussed. We can revert the renamings if you don't like them.

I did not yet touch the issue with the link relations that actually contain an array of link objects instead just a single link object. I would like to discuss how such an array of links should be made available to client code conveniently. I'll open a issue for that.
